### PR TITLE
E0507: Add alternate solution and improve existing

### DIFF
--- a/E0507_cannot_move_out_of_which_is_behind_a_mutable_reference/src/bin/solution_alt.rs
+++ b/E0507_cannot_move_out_of_which_is_behind_a_mutable_reference/src/bin/solution_alt.rs
@@ -1,25 +1,24 @@
-use std::mem;
-
-#[derive(Debug)]
 struct AContainer {
     entries: Vec<String>,
 }
 
 impl AContainer {
     fn enhance(&mut self) {
-        let entries = mem::take(&mut self.entries);
+        let mut new_entries = vec![];
+        let entries = self.entries.to_owned();
 
         for entry in entries {
             if !entry.contains("ignore") {
-                self.entries.push(entry);
+                new_entries.push(entry);
             }
         }
+
+        self.entries = new_entries;
     }
 }
 
 fn main() {
-    let entries = vec!["val".into(), "val ignore".into()];
+    let entries = vec![String::from("val"), String::from("val ignore")];
     let mut container = AContainer { entries };
     container.enhance();
-    println!("{container:?}");
 }


### PR DESCRIPTION
For your current solution, you can use `mem::take` instead of `mem::replace`, since you're replacing with the default value of `Vec` anyway.
Alternatively, you can rely on the optimisation passes to do their thing and manually take ownership of the Vec.

The best thing to do is probably use [Vec::drain_filter](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.drain_filter), e.g.
```rust
struct AContainer {
    entries: Vec<String>
}

impl AContainer {
    fn enhance(&mut self) {
        self.entries.drain_filter(|e| e.contains("ignore"));
    }
}
```
but that's not stable yet, so.